### PR TITLE
add query and spec for a single room by id

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,11 +74,7 @@ GEM
     minitest (5.15.0)
     msgpack (1.4.5)
     nio4r (2.5.8)
-    nokogiri (1.13.3-arm64-darwin)
-      racc (~> 1.4)
     nokogiri (1.13.3-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.13.3-x86_64-linux)
       racc (~> 1.4)
     pg (1.3.4)
     pry (0.14.1)
@@ -125,7 +121,7 @@ GEM
     rspec-mocks (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-rails (5.0.2)
+    rspec-rails (5.0.3)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       railties (>= 5.2)
@@ -161,9 +157,7 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
-  arm64-darwin-20
   x86_64-darwin-20
-  x86_64-linux
 
 DEPENDENCIES
   bootsnap (>= 1.1.0)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,14 +4,19 @@ module Types
     include GraphQL::Types::Relay::HasNodeField
     include GraphQL::Types::Relay::HasNodesField
 
+
+    field :get_room, Types::RoomType, null: false, description: 'Returns a single room by id' do
+      argument :id, ID, required: true
+    end
+
+    def get_room(id:)
+      Room.find(id)
+    end
+
+
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
 
-    # TODO: remove me
-    field :test_field, String, null: false,
-      description: "An example field added by the generator"
-    def test_field
-      "Hello World!"
-    end
+
   end
 end

--- a/app/graphql/types/room_type.rb
+++ b/app/graphql/types/room_type.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Types
+  class RoomType < Types::BaseObject
+    field :id, ID, null: false
+    field :name, String, null: false
+    field :details, String, null: false
+    field :photo, String, null: false
+    field :address, String, null: false
+    field :city, String, null: false
+    field :state, String, null: false
+    field :zip, String, null: false
+    field :price, Float, null: false
+    field :amenities, String, null: false
+    field :instruments, String, null: false
+    field :capacity, Integer, null: false
+    field :created_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,17 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+host_1 = Host.create!(name: 'Chris H', email: 'chris@fake.com', phone: '5595555617')
+Room.create!(id: 1,
+             name: 'Crungalow Studios',
+             details: 'Not spacious or inviting',
+             photo: 'www.photo.com',
+             address: '123 Fake Street',
+             city: 'Denver',
+             state: 'CO',
+             zip: '80211',
+             price: 100.5,
+             amenities: 'coffee maker, wifi',
+             instruments: 'drums, keys, gangsa',
+             capacity: 4,
+             host_id: "#{host_1.id}")

--- a/spec/graphql/queries/rooms/get_single_room_spec.rb
+++ b/spec/graphql/queries/rooms/get_single_room_spec.rb
@@ -1,0 +1,69 @@
+require 'rails_helper'
+
+require 'rails_helper'
+
+RSpec.describe Types::QueryType do
+  describe 'display room' do
+    it 'can query a single room' do
+      host_1 = Host.create!(name: 'Chris H', email: 'chris@fake.com', phone: '5595555617')
+      host_1.rooms.create!(id: 1,
+                   name: 'Crungalow Studios',
+                   details: 'Not spacious or inviting',
+                   photo: 'www.photo.com',
+                   address: '123 Fake Street',
+                   city: 'Denver',
+                   state: 'CO',
+                   zip: '80211',
+                   price: 100.5,
+                   amenities: 'coffee maker, wifi',
+                   instruments: 'drums, keys, gangsa',
+                   capacity: 4
+                   )
+
+      result = RuumBeSchema.execute(query).as_json
+      expect(result["data"]["getRoom"]["name"]).to be_a(String)
+      expect(result["data"]["getRoom"]["details"]).to be_a(String)
+      expect(result["data"]["getRoom"]["photo"]).to be_a(String)
+      expect(result["data"]["getRoom"]["address"]).to be_a(String)
+      expect(result["data"]["getRoom"]["city"]).to be_a(String)
+      expect(result["data"]["getRoom"]["state"]).to be_a(String)
+      expect(result["data"]["getRoom"]["zip"]).to be_a(String)
+      expect(result["data"]["getRoom"]["price"]).to be_a(Float)
+      expect(result["data"]["getRoom"]["amenities"]).to be_a(String)
+      expect(result["data"]["getRoom"]["instruments"]).to be_a(String)
+      expect(result["data"]["getRoom"]["capacity"]).to be_an(Integer)
+    end
+  end
+
+  def query
+    <<~GQL
+    {
+      getRoom(id: "1") {
+        name
+        details
+        photo
+        address
+        city
+        state
+        zip
+        price
+        amenities
+        instruments
+        capacity
+        }
+    }
+    GQL
+  end
+end
+# name
+# details
+# photo
+# address
+# city
+# state
+# zip
+# price
+# amenities
+# instruments
+# capacity
+# host_id


### PR DESCRIPTION
Commit message(s) added to this PR:
    add query and spec for a single room by id
Why is this change necessary (explain like I'm 5)?
Added GraphQL query to find a room by id and return its data. 
What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
Testing: spec/graphql/queries/rooms. Example query in the test. Further testing can be done once merged and pushed to dev environment on heroku. 
Why did we make this change? What Changed? How do we test it?
Further built out graphql functionality. Can be tested locally with postman, or rspec. 

