### PR TITLE
Cors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'graphql', '1.11.6'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
-# gem 'rack-cors'
+gem 'rack-cors'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.7)
@@ -187,6 +189,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry
   puma (~> 4.3.11)
+  rack-cors
   rails (~> 5.2.7)
   rspec-rails (~> 5.0.0)
   rspec_junit_formatter
@@ -198,4 +201,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.3.4
+   2.3.7

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins 'example.com'
-#
-#     resource '*',
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins 'example.com'
+
+    resource '*',
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'example.com'
+    origins 'http://localhost:3000'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
Commit message(s) added to this PR: 

Why is this change necessary (explain like I'm 5)?
This change enables the rack-Cors gem, to enable the front end and backend to talk to eachother using the cors gem. 

What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
Cors should be enabled for the frontend to be able to access the backend.

Why did we make this change? What Changed? How do we test it?
We needed it for frontend and backend to be able to talk. We are going to test it by seeing if the frontend can make fetch calls of the backend.
