### PR TITLE
Add destroy booking by ID and spec

### DIFF
--- a/app/graphql/mutations/destroy_booking.rb
+++ b/app/graphql/mutations/destroy_booking.rb
@@ -1,0 +1,12 @@
+module Mutations
+  class DestroyBooking < BaseMutation
+    argument :booking_id, String, required: true
+
+    type Types::BookingType
+
+
+    def resolve(booking_id:)
+      Booking.find(booking_id).destroy
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
+    field :destroy_booking, mutation: Mutations::DestroyBooking
     field :create_musician, mutation: Mutations::CreateMusician
     field :create_booking, mutation: Mutations::CreateBooking
   end

--- a/spec/graphql/mutations/destroy_booking_spec.rb
+++ b/spec/graphql/mutations/destroy_booking_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+RSpec.describe "Destroybooking", type: :request do
+  describe 'delete mutation' do
+
+  it "deletes a booking when provided an id" do
+      musician = create(:musician, id: '22')
+      room = create(:room, id: '70')
+
+      post '/graphql', params: { query: create_query }
+      expect(Booking.count).to eq(1)
+      booking_id = Booking.last.id.to_s
+
+      result = RuumBeSchema.execute(delete_query).as_json
+
+      expect(Booking.all.count).to eq(0)
+      expect(result["data"].keys).to eq(["destroyBooking"])
+      expect(result["data"]["destroyBooking"]["id"]).to eq(booking_id)
+    end
+  end
+
+  def create_query
+    <<~GQL
+            mutation {
+              createBooking(input: {date: "Mon Apr 29 2022", musicianId: "22", roomId: "70"}) {
+                date
+                musician {
+                  id
+                  name
+                }
+                room {
+                  id
+                  name
+                  details
+                  photo
+                  price
+                }
+              }
+            }
+            GQL
+  end
+
+  def delete_query
+    <<~GQL
+    mutation {
+          destroyBooking(
+            input: {bookingId: "#{Booking.last.id}"}) {
+            id
+          }
+        }
+    GQL
+  end
+end


### PR DESCRIPTION
Commit message(s) added to this PR:
    Add destroy booking by ID and spec

Why is this change necessary (explain like I'm 5)?
Add functionality for a graphQL mutation that destroys(cancels) a booking by ID. 

What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
New functionality added. Can be tested through Rspec additionals(spec/graphql/mutationsdestroy_booking_spec), or on localhost with graphiql. 

Why did we make this change? What Changed? How do we test it?
Made changes to move closer to BE mvp. Testing details above. 
