### PR TITLE
refactor create_musician mutation to include AuthProvider

### DIFF
--- a/app/graphql/mutations/create_musician.rb
+++ b/app/graphql/mutations/create_musician.rb
@@ -2,20 +2,22 @@
 
 module Mutations
   class CreateMusician < BaseMutation
+    class AuthProviderSignupData < Types::BaseInputObject
+      argument :credentials, Types::AuthProviderCredentialsInput, required: false
+    end
     argument :name, String, required: true
-    argument :password, String, required: true
-    argument :email, String, required: true
     argument :phone, String, required: true
     argument :photo, String, required: true
+    argument :auth_provider, AuthProviderSignupData, required: false
 
 
     type Types::MusicianType
 
-    def resolve(name: nil, email: nil, password: nil, phone: nil, photo: nil)
+    def resolve(name: nil, auth_provider: nil, phone: nil, photo: nil)
       Musician.create!(
         name: name,
-        email: email,
-        password: password,
+        email: auth_provider&.[](:credentials)&.[](:email),
+        password: auth_provider&.[](:credentials)&.[](:password),
         phone: phone,
         photo: photo
       )

--- a/app/graphql/mutations/sign_in_musician.rb
+++ b/app/graphql/mutations/sign_in_musician.rb
@@ -17,9 +17,10 @@ module Mutations
       return unless musician
       return unless musician.authenticate(credentials[:password])
 
-      # use Ruby on Rails - ActiveSupport::MessageEncryptor, to build a token
-      binding.pry
-      crypt = ActiveSupport::MessageEncryptor.new(Rails.application.credentials.secret_key_base.byteslice(0..31))
+      len = ActiveSupport::MessageEncryptor.key_len
+      salt  = SecureRandom.random_bytes(len)
+      key   = ActiveSupport::KeyGenerator.new('password').generate_key(salt, len)
+      crypt = ActiveSupport::MessageEncryptor.new(key)
       token = crypt.encrypt_and_sign("musician-id:#{ musician.id }")
 
       { musician: musician, token: token }

--- a/app/graphql/mutations/sign_in_musician.rb
+++ b/app/graphql/mutations/sign_in_musician.rb
@@ -1,0 +1,28 @@
+module Mutations
+  class SignInMusician < BaseMutation
+    null true
+
+    argument :credentials, Types::AuthProviderCredentialsInput, required: false
+
+    field :token, String, null: true
+    field :musician, Types::MusicianType, null: true
+
+    def resolve(credentials: nil)
+      # basic validation
+      return unless credentials
+
+      musician = Musician.find_by email: credentials[:email]
+
+      # ensures we have the correct user
+      return unless musician
+      return unless musician.authenticate(credentials[:password])
+
+      # use Ruby on Rails - ActiveSupport::MessageEncryptor, to build a token
+      binding.pry
+      crypt = ActiveSupport::MessageEncryptor.new(Rails.application.credentials.secret_key_base.byteslice(0..31))
+      token = crypt.encrypt_and_sign("musician-id:#{ musician.id }")
+
+      { musician: musician, token: token }
+    end
+  end
+end

--- a/app/graphql/types/auth_provider_credentials_input.rb
+++ b/app/graphql/types/auth_provider_credentials_input.rb
@@ -1,0 +1,8 @@
+module Types
+  class AuthProviderCredentialsInput < BaseInputObject
+    graphql_name 'AUTH_PROVIDER_CREDENTIALS'
+
+    argument :email, String, required: true
+    argument :password, String, required: true
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -5,5 +5,6 @@ module Types
     field :destroy_musician, mutation: Mutations::DestroyMusician
     field :update_musician, mutation: Mutations::UpdateMusician
     field :create_booking, mutation: Mutations::CreateBooking
+    field :sign_in_musician, mutation: Mutations::SignInMusician
   end
 end

--- a/spec/graphql/mutations/create_musician_spec.rb
+++ b/spec/graphql/mutations/create_musician_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'CreateMusician', type: :request do
     it "creates a user with given information" do
       post '/graphql', params: { query: query }
       parsed = JSON.parse(response.body)
+
       expect(parsed["data"]["createMusician"]).to have_key("id")
       expect(parsed["data"]["createMusician"]["name"]).to eq("John Coltrane")
       expect(parsed["data"]["createMusician"]["email"]).to eq("john@space.com")
@@ -32,8 +33,12 @@ RSpec.describe 'CreateMusician', type: :request do
       mutation {
       createMusician(input: {
         name: "John Coltrane",
-        email: "john@space.com",
-        password: "password",
+        authProvider: {
+          credentials: {
+            email: "john@space.com",
+            password: "password"
+          }
+        }
         phone: "5597995639",
         photo: "www.photo.com"})
         { id

--- a/spec/graphql/mutations/sign_in_musician_spec.rb
+++ b/spec/graphql/mutations/sign_in_musician_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+RSpec.describe "sign in mutation", type: :request do
+  it "signs in musician after authentication" do
+    musician_1 = Musician.create!(email: "bruce@mail.com", password: "password", name: "Phil Brazil", photo: "www.photo.com", phone: '5597995111')
+    post '/graphql', params: { query: query }
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    expect(response_body[:data][:signInMusician][:token]).to be_a(String)
+    expect(response_body[:data][:signInMusician][:token].length).to eq(76)
+    expect(response_body[:data][:signInMusician][:musician][:id]).to eq(musician_1.id.to_s)
+  end
+
+  def query
+    <<~GQL
+    mutation {
+      signInMusician(
+    input: {credentials: {email: "bruce@mail.com", password: "password"}}
+    ) {
+    token
+    musician {
+      id
+      }
+    }
+  }
+  GQL
+  end
+end


### PR DESCRIPTION
Commit message(s) added to this PR:
    refactor create_musician mutation to include AuthProvider


Why is this change necessary (explain like I'm 5)?
Updated exiting create_musician mutation to accept data from AuthProvider. Abstracts authentication into new type,  AuthProviderCredentialsInput. 

What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
Queries for create musician now changed and include nested AuthProvider input field. Can test in RSpec or postman. 
Why did we make this change? What Changed? How do we test it?
Change is necessary for including authentication on the application for register/login. Current functionality reflects registration. 
