### PR TITLE
Cors and puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '~> 5.2.7'
 # Use postgresql as the database for Active Record
 gem 'pg', '>= 0.18', '< 2.0'
 # Use Puma as the app server
-gem 'puma', '~> 4.3.11'
+gem 'puma', '~> 4.3.12'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,7 +95,7 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    puma (4.3.11)
+    puma (4.3.12)
       nio4r (~> 2.0)
     racc (1.6.0)
     rack (2.2.3)
@@ -190,7 +190,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry
-  puma (~> 4.3.11)
+  puma (~> 4.3.12)
   rack-cors
   rails (~> 5.2.7)
   rspec-rails (~> 5.0.0)

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'http://localhost:3000'
+    origins 'http://localhost:3000', '\Ahttps:\/\/ruumproject\.herokuapp\.com\z'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
Commit message(s) added to this PR:
Adds FE Heroku site as allowed origin in rack-cors
Updates puma per Dependabot alerts on Github

Why is this change necessary (explain like I'm 5)?
The FE Heroku site needs to be able to call the BE api without CORS errors. Also, dependabot has been warning us about a vulnerability in puma and recommended we update to v 4.3.12.

What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
Version in Gemfile and Gemfile.lock; added one item to the rack-cors config file in config/initializers.

Why did we make this change? What Changed? How do we test it?
In an effort to ensure the FE prod site can access the BE prod API. (We may still need to do some trial and error even after this change.)