### PR TITLE
Adds error handling if authentication fails

### DIFF
--- a/app/graphql/mutations/sign_in_musician.rb
+++ b/app/graphql/mutations/sign_in_musician.rb
@@ -14,16 +14,16 @@ module Mutations
       musician = Musician.find_by email: credentials[:email]
 
       # ensures we have the correct user
-      return unless musician
-      return unless musician.authenticate(credentials[:password])
-
-      len = ActiveSupport::MessageEncryptor.key_len
-      salt  = SecureRandom.random_bytes(len)
-      key   = ActiveSupport::KeyGenerator.new('password').generate_key(salt, len)
-      crypt = ActiveSupport::MessageEncryptor.new(key)
-      token = crypt.encrypt_and_sign("musician-id:#{ musician.id }")
-
-      { musician: musician, token: token }
+      if musician && musician.authenticate(credentials[:password])
+        len = ActiveSupport::MessageEncryptor.key_len
+        salt  = SecureRandom.random_bytes(len)
+        key   = ActiveSupport::KeyGenerator.new('password').generate_key(salt, len)
+        crypt = ActiveSupport::MessageEncryptor.new(key)
+        token = crypt.encrypt_and_sign("musician-id:#{musician.id}")
+        { musician: musician, token: token }
+      else
+        GraphQL::ExecutionError.new('Invalid login credentials')
+      end
     end
   end
 end

--- a/spec/graphql/mutations/sign_in_musician_spec.rb
+++ b/spec/graphql/mutations/sign_in_musician_spec.rb
@@ -23,4 +23,28 @@ RSpec.describe "sign in mutation", type: :request do
   }
   GQL
   end
+
+  it 'errors on failure to authenticate' do
+    musician_2 = Musician.create!(email: 'bruce@mail.com', password: 'password', name: 'Phil Brazil', photo: 'www.photo.com', phone: '5597995111')
+    post '/graphql', params: { query: query2 }
+    response_body = JSON.parse(response.body, symbolize_names: true)
+    
+    expect(response_body[:data][:signInMusician]).to eq(nil)
+    expect(response_body[:errors][0][:message]).to eq('Invalid login credentials')
+  end
+
+  def query2
+    <<~GQL
+    mutation {
+      signInMusician(
+    input: {credentials: {email: "bruce@mail.com", password: "pass"}}
+    ) {
+    token
+    musician {
+      id
+      }
+    }
+  }
+  GQL
+  end
 end

--- a/spec/graphql/mutations/sign_in_musician_spec.rb
+++ b/spec/graphql/mutations/sign_in_musician_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "sign in mutation", type: :request do
     
     expect(response_body[:data][:signInMusician]).to eq(nil)
     expect(response_body[:errors][0][:message]).to eq('Invalid login credentials')
+    expect(response_body[:errors][0][:extensions][:code]).to eq('UNAUTHORIZED')
   end
 
   def query2


### PR DESCRIPTION
Commit message(s) added to this PR:
Adds error handling if authentication fails

Why is this change necessary (explain like I'm 5)?
If the user credentials provided aren't valid, we need to respond with an error.

What changed technically that may impact others? Step-by-step instructions to test that it's working as intended.
we added some logic to SignInMutation to respond with an error on failed login.

Why did we make this change? What Changed? How do we test it?
SignInMutation and the associated test changed. Test with provided spec!